### PR TITLE
Remove Start Game from chat flow

### DIFF
--- a/components/assistant.tsx
+++ b/components/assistant.tsx
@@ -5,8 +5,12 @@ import useConversationStore from "@/stores/useConversationStore";
 import { Item, processMessages } from "@/lib/assistant";
 
 export default function Assistant() {
-  const { chatMessages, addConversationItem, addChatMessage, setAssistantLoading } =
-    useConversationStore();
+  const {
+    chatMessages,
+    addConversationItem,
+    addChatMessage,
+    setAssistantLoading,
+  } = useConversationStore();
 
   const handleSendMessage = async (message: string) => {
     if (!message.trim()) return;
@@ -31,9 +35,19 @@ export default function Assistant() {
     }
   };
 
+  const startConversation = async () => {
+    try {
+      setAssistantLoading(true);
+      addConversationItem({ role: "user", content: "Start game" } as any);
+      await processMessages();
+    } catch (error) {
+      console.error("Error starting conversation:", error);
+    }
+  };
+
   useEffect(() => {
-    if (chatMessages.length === 1) {
-      handleSendMessage("Start game");
+    if (chatMessages.length === 0) {
+      startConversation();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/stores/useConversationStore.ts
+++ b/stores/useConversationStore.ts
@@ -1,7 +1,6 @@
 import { create } from "zustand";
 import { Item } from "@/lib/assistant";
 import { ChatCompletionMessageParam } from "openai/resources/chat/completions";
-import { INITIAL_MESSAGE } from "@/config/constants";
 
 interface ConversationState {
   // Items displayed in the chat
@@ -20,13 +19,7 @@ interface ConversationState {
 }
 
 const useConversationStore = create<ConversationState>((set) => ({
-  chatMessages: [
-    {
-      type: "message",
-      role: "assistant",
-      content: [{ type: "output_text", text: INITIAL_MESSAGE }],
-    },
-  ],
+  chatMessages: [],
   conversationItems: [],
   isAssistantLoading: false,
   setChatMessages: (items) => set({ chatMessages: items }),


### PR DESCRIPTION
## Summary
- initialize conversation with no pre-set messages
- hide the `"Start game"` user message and send it only to the API

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68783a43238c832f8324f80c7cfbcf2a