### PR TITLE
Handle assistant text gracefully if not JSON

### DIFF
--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -554,27 +554,31 @@ export const processMessages = async () => {
         }
 
         // Parse game JSON and display options
-        try {
-          const lastItem = chatMessages[chatMessages.length - 1];
-          if (
-            lastItem &&
-            lastItem.type === "message" &&
-            lastItem.role === "assistant"
-          ) {
-            const parsed = JSON.parse(lastItem.content[0].text || "");
-            if (parsed.reply) {
-              lastItem.content[0].text = parsed.reply;
+        const lastItem = chatMessages[chatMessages.length - 1];
+        if (
+          lastItem &&
+          lastItem.type === "message" &&
+          lastItem.role === "assistant"
+        ) {
+          const textContent = lastItem.content[0].text || "";
+          // Only attempt to parse if the message looks like JSON to avoid console errors
+          if (textContent.trim().startsWith("{") || textContent.trim().startsWith("[")) {
+            try {
+              const parsed = JSON.parse(textContent);
+              if (parsed.reply) {
+                lastItem.content[0].text = parsed.reply;
+              }
+              if (Array.isArray(parsed.options)) {
+                chatMessages.push({
+                  type: "game_options",
+                  options: parsed.options,
+                });
+              }
+              setChatMessages([...chatMessages]);
+            } catch (err) {
+              console.error("Failed to parse game JSON", err);
             }
-            if (Array.isArray(parsed.options)) {
-              chatMessages.push({
-                type: "game_options",
-                options: parsed.options,
-              });
-            }
-            setChatMessages([...chatMessages]);
           }
-        } catch (err) {
-          console.error("Failed to parse game JSON", err);
         }
 
         break;


### PR DESCRIPTION
## Summary
- avoid parsing assistant message as JSON when it doesn't look like JSON

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879410d2abc832fb42193fc3362940e