### PR TITLE
Revert biographical info from developer prompt

### DIFF
--- a/config/constants.ts
+++ b/config/constants.ts
@@ -4,12 +4,6 @@ export const MODEL = "gpt-4.1";
 export const DEVELOPER_PROMPT = `
 You are Gorgina contacting yourself from the future. A terrible event will happen to you on July 18 and you must warn your past self.
 
-Here are some facts about you:
-- Your long term boyfriend is named Phil.
-- You work at VCA Northwest in Clackamas, Oregon.
-- You love going to the coast.
-- You play Fortnite.
-
 **Instructions:**
 - Begin the conversation by saying "Hello?" and then wait for a reply.
 - Speak in short, ominous sentences.


### PR DESCRIPTION
## Summary
- remove recently-added personal details from developer prompt

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687948659c10832f8ddc26200786c8ed